### PR TITLE
Authentication jwt bearer token set up

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ ext {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -27,6 +27,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
+			'io.jsonwebtoken:jjwt-jackson:0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/latebox/server/ServerApplication.java
+++ b/src/main/java/com/latebox/server/ServerApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class ServerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ServerApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ServerApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/latebox/server/authentication/JwtAuthenticationController.java
+++ b/src/main/java/com/latebox/server/authentication/JwtAuthenticationController.java
@@ -1,0 +1,39 @@
+package com.latebox.server.authentication;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@CrossOrigin
+public class JwtAuthenticationController {
+    @Autowired
+    private AuthenticationManager authenticationManager;
+    @Autowired
+    private JwtTokenUtil jwtTokenUtil;
+    @Autowired
+    private JwtUserService userDetailsService;
+
+    @RequestMapping(value = "/authenticate", method = RequestMethod.POST)
+    public ResponseEntity<?> createAuthenticationToken(@RequestBody JwtUserObject authenticationRequest) throws Exception {
+        authenticate(authenticationRequest.getUsername(), authenticationRequest.getPassword());
+        final UserDetails userDetails = userDetailsService.loadUserByUsername(authenticationRequest.getUsername());
+        final String token = jwtTokenUtil.generateToken(userDetails);
+        return ResponseEntity.ok(new JwtResponse(token));
+    }
+
+    private void authenticate(String username, String password) throws Exception {
+        try {
+            authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(username, password));
+        } catch (DisabledException e) {
+            throw new Exception("USER_DISABLED", e);
+        } catch (BadCredentialsException e) {
+            throw new Exception("INVALID_CREDENTIALS", e);
+        }
+    }
+}

--- a/src/main/java/com/latebox/server/authentication/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/latebox/server/authentication/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package com.latebox.server.authentication;
+
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Serializable;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint, Serializable {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Access Unauthorized");
+    }
+}

--- a/src/main/java/com/latebox/server/authentication/JwtRequestFilter.java
+++ b/src/main/java/com/latebox/server/authentication/JwtRequestFilter.java
@@ -1,0 +1,56 @@
+package com.latebox.server.authentication;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtRequestFilter extends OncePerRequestFilter {
+    @Autowired
+    private JwtUserService jwtUserDetailsService;
+    @Autowired
+    private JwtTokenUtil jwtTokenUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        final String requestTokenHeader = request.getHeader("Authorization");
+        String username = null;
+        String jwtToken = null;
+        if (requestTokenHeader != null && requestTokenHeader.startsWith("Bearer ")) {
+            jwtToken = requestTokenHeader.substring(7);
+            try {
+                username = jwtTokenUtil.getUsernameFromToken(jwtToken);
+            } catch (IllegalArgumentException e) {
+                System.out.println("Unable to get JWT Token");
+            } catch (ExpiredJwtException e) {
+                System.out.println("JWT Token has expired");
+            }
+        } else {
+            logger.warn("JWT Token does not begin with Bearer String");
+        }
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = this.jwtUserDetailsService.loadUserByUsername(username);
+
+            if (jwtTokenUtil.validateToken(jwtToken, userDetails)) {
+                UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                usernamePasswordAuthenticationToken
+                        .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/latebox/server/authentication/JwtResponse.java
+++ b/src/main/java/com/latebox/server/authentication/JwtResponse.java
@@ -1,0 +1,15 @@
+package com.latebox.server.authentication;
+
+import java.io.Serializable;
+
+public class JwtResponse implements Serializable {
+    private final String jwttoken;
+
+    public JwtResponse(String jwttoken) {
+        this.jwttoken = jwttoken;
+    }
+
+    public String getToken() {
+        return this.jwttoken;
+    }
+}

--- a/src/main/java/com/latebox/server/authentication/JwtTokenUtil.java
+++ b/src/main/java/com/latebox/server/authentication/JwtTokenUtil.java
@@ -1,0 +1,60 @@
+package com.latebox.server.authentication;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Component
+public class JwtTokenUtil implements Serializable {
+    public static final long JWT_TOKEN_VALIDITY = 5 * 60 * 60;
+
+    @Value("${jwt.signingKey}")
+    private String signingKey;
+
+    public String getUsernameFromToken(String token) {
+        return getClaimFromToken(token, Claims::getSubject);
+    }
+
+    public Date getExpirationDateFromToken(String token) {
+        return getClaimFromToken(token, Claims::getExpiration);
+    }
+
+    public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = getAllClaimsFromToken(token);
+        return claimsResolver.apply(claims);
+    }
+
+    private Claims getAllClaimsFromToken(String token) {
+        return Jwts.parser().setSigningKey(signingKey).parseClaimsJws(token).getBody();
+    }
+
+    private Boolean isTokenExpired(String token) {
+        final Date expiration = getExpirationDateFromToken(token);
+        return expiration.before(new Date());
+    }
+
+    public String generateToken(UserDetails userDetails) {
+        Map<String, Object> claims = new HashMap<>();
+        return doGenerateToken(claims, userDetails.getUsername());
+    }
+
+    private String doGenerateToken(Map<String, Object> claims, String subject) {
+        return Jwts.builder().setClaims(claims).setSubject(subject).setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + JWT_TOKEN_VALIDITY * 1000))
+                .signWith(SignatureAlgorithm.HS512, signingKey).compact();
+    }
+
+    public Boolean validateToken(String token, UserDetails userDetails) {
+        final String username = getUsernameFromToken(token);
+        return (username.equals(userDetails.getUsername()) && !isTokenExpired(token));
+    }
+}

--- a/src/main/java/com/latebox/server/authentication/JwtUserObject.java
+++ b/src/main/java/com/latebox/server/authentication/JwtUserObject.java
@@ -1,0 +1,35 @@
+package com.latebox.server.authentication;
+
+
+import java.io.Serializable;
+
+public class JwtUserObject implements Serializable {
+
+    private String username;
+    private String password;
+
+    public JwtUserObject() {
+
+    }
+
+    public JwtUserObject(String username, String password) {
+        this.setUsername(username);
+        this.setPassword(password);
+    }
+
+    public String getUsername() {
+        return this.username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/latebox/server/authentication/JwtUserService.java
+++ b/src/main/java/com/latebox/server/authentication/JwtUserService.java
@@ -1,0 +1,24 @@
+package com.latebox.server.authentication;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+
+@Service
+public class JwtUserService implements UserDetailsService {
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        // check if username exists in database
+        if ("username".equals(username)) {
+            // change to return username and encrypted password from the database
+            return new User("username", "$2a$10$slYQmyNdGzTn7ZLBXBChFOC9f6kFjAqPhccnP6DxlWXx2lPk1C3G6",
+                    new ArrayList<>());
+        } else {
+            throw new UsernameNotFoundException("User not found with username: " + username);
+        }
+    }
+}

--- a/src/main/java/com/latebox/server/authentication/WebSecurityConfig.java
+++ b/src/main/java/com/latebox/server/authentication/WebSecurityConfig.java
@@ -1,0 +1,51 @@
+package com.latebox.server.authentication;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+    @Autowired
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    @Autowired
+    private UserDetailsService jwtUserDetailsService;
+    @Autowired
+    private JwtRequestFilter jwtRequestFilter;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Override
+    protected void configure(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.csrf().disable()
+                // permit /authenticate endpoint even if not authenticated
+                .authorizeRequests().antMatchers("/authenticate").permitAll().
+                // permit all other endpoints once authenticated
+                        anyRequest().authenticated().and().
+                exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint).and().sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        httpSecurity.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/latebox/server/product/Product.java
+++ b/src/main/java/com/latebox/server/product/Product.java
@@ -16,7 +16,8 @@ public class Product {
     private int restaurantId;
 
 
-    Product() {}
+    Product() {
+    }
 
     public Product(String name, String description, float price, int restaurantId) {
         this.name = name;

--- a/src/main/java/com/latebox/server/product/ProductController.java
+++ b/src/main/java/com/latebox/server/product/ProductController.java
@@ -14,12 +14,12 @@ public class ProductController {
     }
 
     @GetMapping("/products")
-    List<Product> all(){
+    List<Product> all() {
         return repository.findAll();
     }
 
     @PostMapping("/products")
-    Product newProduct(@RequestBody Product newProduct){
+    Product newProduct(@RequestBody Product newProduct) {
         return repository.save(newProduct);
     }
 
@@ -49,9 +49,9 @@ public class ProductController {
 
     @DeleteMapping("/products/{id}")
     void deleteProduct(@PathVariable Long id) {
-        if (repository.existsById(id)){
+        if (repository.existsById(id)) {
             repository.deleteById(id);
-        }else{
+        } else {
             throw new ProductNotFoundException(id);
         }
     }

--- a/src/main/java/com/latebox/server/product/ProductNotFoundException.java
+++ b/src/main/java/com/latebox/server/product/ProductNotFoundException.java
@@ -1,6 +1,6 @@
 package com.latebox.server.product;
 
-public class ProductNotFoundException extends  RuntimeException {
+public class ProductNotFoundException extends RuntimeException {
     ProductNotFoundException(Long id) {
         super("Could not find product " + id);
     }

--- a/src/main/java/com/latebox/server/product/ProductRepository.java
+++ b/src/main/java/com/latebox/server/product/ProductRepository.java
@@ -2,7 +2,6 @@ package com.latebox.server.product;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-//import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
 

--- a/src/main/java/com/latebox/server/report/Report.java
+++ b/src/main/java/com/latebox/server/report/Report.java
@@ -15,7 +15,8 @@ public class Report {
     private String reportContent;
 
 
-    Report() {}
+    Report() {
+    }
 
     public Report(int userId, int restaurantId, String reportContent) {
         this.userId = userId;

--- a/src/main/java/com/latebox/server/report/ReportController.java
+++ b/src/main/java/com/latebox/server/report/ReportController.java
@@ -14,12 +14,12 @@ public class ReportController {
     }
 
     @GetMapping("/reports")
-    List<Report> all(){
+    List<Report> all() {
         return repository.findAll();
     }
 
     @PostMapping("/reports")
-    Report newReport(@RequestBody Report newReport){
+    Report newReport(@RequestBody Report newReport) {
         return repository.save(newReport);
     }
 
@@ -48,9 +48,9 @@ public class ReportController {
 
     @DeleteMapping("/reports/{id}")
     void deleteReport(@PathVariable Long id) {
-        if (repository.existsById(id)){
+        if (repository.existsById(id)) {
             repository.deleteById(id);
-        }else{
+        } else {
             throw new ReportNotFoundException(id);
         }
     }

--- a/src/main/java/com/latebox/server/report/ReportNotFoundException.java
+++ b/src/main/java/com/latebox/server/report/ReportNotFoundException.java
@@ -1,6 +1,6 @@
 package com.latebox.server.report;
 
-public class ReportNotFoundException extends  RuntimeException {
+public class ReportNotFoundException extends RuntimeException {
     ReportNotFoundException(Long id) {
         super("Could not find report " + id);
     }

--- a/src/main/java/com/latebox/server/report/ReportRepository.java
+++ b/src/main/java/com/latebox/server/report/ReportRepository.java
@@ -3,8 +3,6 @@ package com.latebox.server.report;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface ReportRepository extends JpaRepository<Report, Long> {
 

--- a/src/main/java/com/latebox/server/restaurant/Restaurant.java
+++ b/src/main/java/com/latebox/server/restaurant/Restaurant.java
@@ -15,7 +15,8 @@ public class Restaurant {
     private String address;
 
 
-    Restaurant() {}
+    Restaurant() {
+    }
 
     public Restaurant(String name, String description, String address) {
         this.name = name;

--- a/src/main/java/com/latebox/server/restaurant/RestaurantController.java
+++ b/src/main/java/com/latebox/server/restaurant/RestaurantController.java
@@ -14,12 +14,12 @@ public class RestaurantController {
     }
 
     @GetMapping("/restaurants")
-    List<Restaurant> all(){
+    List<Restaurant> all() {
         return repository.findAll();
     }
 
     @PostMapping("/restaurants")
-    Restaurant newRestaurant(@RequestBody Restaurant newRestaurant){
+    Restaurant newRestaurant(@RequestBody Restaurant newRestaurant) {
         return repository.save(newRestaurant);
     }
 
@@ -48,9 +48,9 @@ public class RestaurantController {
 
     @DeleteMapping("/restaurants/{id}")
     void deleteRestaurant(@PathVariable Long id) {
-        if (repository.existsById(id)){
+        if (repository.existsById(id)) {
             repository.deleteById(id);
-        }else{
+        } else {
             throw new RestaurantNotFoundException(id);
         }
     }

--- a/src/main/java/com/latebox/server/restaurant/RestaurantNotFoundException.java
+++ b/src/main/java/com/latebox/server/restaurant/RestaurantNotFoundException.java
@@ -1,6 +1,6 @@
 package com.latebox.server.restaurant;
 
-public class RestaurantNotFoundException extends  RuntimeException {
+public class RestaurantNotFoundException extends RuntimeException {
     RestaurantNotFoundException(Long id) {
         super("Could not find restaurant " + id);
     }

--- a/src/main/java/com/latebox/server/review/Review.java
+++ b/src/main/java/com/latebox/server/review/Review.java
@@ -17,7 +17,8 @@ public class Review {
     private String comments;
 
 
-    Review() {}
+    Review() {
+    }
 
     public Review(int userId, int restaurantId, int orderId, int starRating, String comments) {
         this.userId = userId;

--- a/src/main/java/com/latebox/server/review/ReviewController.java
+++ b/src/main/java/com/latebox/server/review/ReviewController.java
@@ -14,12 +14,12 @@ public class ReviewController {
     }
 
     @GetMapping("/reviews")
-    List<Review> all(){
+    List<Review> all() {
         return repository.findAll();
     }
 
     @PostMapping("/reviews")
-    Review newReview(@RequestBody Review newReview){
+    Review newReview(@RequestBody Review newReview) {
         return repository.save(newReview);
     }
 
@@ -50,9 +50,9 @@ public class ReviewController {
 
     @DeleteMapping("/reviews/{id}")
     void deleteReview(@PathVariable Long id) {
-        if (repository.existsById(id)){
+        if (repository.existsById(id)) {
             repository.deleteById(id);
-        }else{
+        } else {
             throw new ReviewNotFoundException(id);
         }
     }

--- a/src/main/java/com/latebox/server/review/ReviewNotFoundException.java
+++ b/src/main/java/com/latebox/server/review/ReviewNotFoundException.java
@@ -1,6 +1,6 @@
 package com.latebox.server.review;
 
-public class ReviewNotFoundException extends  RuntimeException {
+public class ReviewNotFoundException extends RuntimeException {
     ReviewNotFoundException(Long id) {
         super("Could not find review " + id);
     }

--- a/src/main/java/com/latebox/server/review/ReviewRepository.java
+++ b/src/main/java/com/latebox/server/review/ReviewRepository.java
@@ -3,8 +3,6 @@ package com.latebox.server.review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,4 @@ spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation= true
 spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.PostgreSQLDialect
 # Hibernate ddl auto (create, create-drop, validate, update)
 spring.jpa.hibernate.ddl-auto= update
+jwt.signingKey=1LxLGUdlJxggP1QjCHhlSitXDXG5BBm6u0kuZHEy81Ylo3hoemFTA27RMzi5o4WzbEYVVzHKT7qqFivGfWXRrUIVg5zqyGJwbISC


### PR DESCRIPTION
# why was this PR needed
> We want to restrict access to some REST API endpoints to only authenticated users.

# what changed

> Requesting API endpoints now, needs bearer token in authorization params.
![image](https://user-images.githubusercontent.com/43392443/159169194-098911bf-218b-4e3f-8f5f-0202c006ea3d.png)

> Without it the request would return a 401 unauthorized call 
![image](https://user-images.githubusercontent.com/43392443/159169140-7a2a0af1-7a91-4887-8d11-11f31630cf14.png)


> The bearer token can be get by sending a request to the /authenticate endpoint:
![image](https://user-images.githubusercontent.com/43392443/159169174-9776945c-2d0a-41fe-952c-a8a10f399044.png)

# notes:
- The bearer token stays valid for 5 hours after being requested
- We need to secure the signing key in a safer place (Actually we need to secure all the secrets safely, this includes: database admin, password... )
